### PR TITLE
Also support TypeScript

### DIFF
--- a/eslint-plugin-ignore-generated.js
+++ b/eslint-plugin-ignore-generated.js
@@ -31,5 +31,7 @@ module.exports = {
     '.js': processor,
     '.jsx': processor,
     '.flow': processor,
+    '.ts': processor,
+    '.tsx': processor,
   },
 };


### PR DESCRIPTION
I'm not an expert in this, but this change seems to make this plugin ignore generated TypeScript files now.